### PR TITLE
Support of autofocus in a modal

### DIFF
--- a/dist/ng-autofocus.js
+++ b/dist/ng-autofocus.js
@@ -9,12 +9,14 @@
 
   angular
     .module('ng-autofocus', [])
-    .directive('autofocus', function() {
+    .directive('autofocus', ['$timeout', function($timeout) {
       return {
         restrict: 'A',
         link: function($scope, element) {
-          element[0].focus();
+          $timeout(function() {
+            element[0].focus();
+          });
         }
       };
-    });
+    }]);
 })(angular);

--- a/dist/ng-autofocus.min.js
+++ b/dist/ng-autofocus.min.js
@@ -1,1 +1,1 @@
-!function(u){"use strict";u.module("ng-autofocus",[]).directive("autofocus",function(){return{restrict:"A",link:function(u,t){t[0].focus()}}})}(angular);
+!function(t){"use strict";t.module("ng-autofocus",[]).directive("autofocus",["$timeout",function(t){return{restrict:"A",link:function(u,n){t(function(){n[0].focus()})}}}])}(angular);

--- a/src/ng-autofocus.js
+++ b/src/ng-autofocus.js
@@ -9,12 +9,14 @@
 
   angular
     .module('ng-autofocus', [])
-    .directive('autofocus', function() {
+    .directive('autofocus', ['$timeout', function($timeout) {
       return {
         restrict: 'A',
         link: function($scope, element) {
-          element[0].focus();
+          $timeout(function() {
+            element[0].focus();
+          });
         }
       };
-    });
+    }]);
 })(angular);


### PR DESCRIPTION
The directive does not work when a form is loaded in a modal. It can be solved by wrapping the `focus()` call in the `$timeout` service. See http://plnkr.co/edit/NTSKnADit8nHhX4BSsTp?p=preview
